### PR TITLE
Wait for the swift server to boot

### DIFF
--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -209,7 +209,7 @@ def StopCompleterServer( app, filetype, filepath = '/foo' ):
                  expect_errors = True )
 
 
-def WaitUntilCompleterServerReady( app, filetype, timeout = 30 ):
+def WaitUntilCompleterServerReady( app, filetype, timeout = 40 ):
   expiration = time.time() + timeout
   while True:
     if time.time() > expiration:


### PR DESCRIPTION
[Stability] Wait on Swifty Swift Vim boot

Wait for initial Swifty Swift Vim Boot. Tasks in the backend's startup
process ( like dynamic linking and setting up the HTTP stack ) make it
impossible for the backend to respond to requests immediately after
launching the process. If the process isn't ready, YCMD will fail. It
simply waits until the process writes to stdout, which in practice is
the loading message.

Profiling:
Runs were made on a 2014 MBA ( 1.4 GHz Intel Core i5 ). I observed
booting to be reasonably quick. Right after starting the machine, it
took less than 100ms. After starting the service once it was
dramatically reduced. I used a 5 second timeout because I don't see a
good to make it much smaller and I don't have access to lower perf
hardware for developing this.

Stability:
I assume this is why the CI was failing here and there. I also tested
adding a sleep before the tests yielded stability on the CI after
several runs ( see jerrymarino/ycmd Travis build history of
jmarino_health_check_completion_tests ). @puremourning also reported he
was seeing timeouts. I was also able to consistently see timeouts in vim
and fail the test suite immediately after starting the test machine.

Reproduction Steps:
- run the test suite immediately after system start
- open Vim immediately after system start